### PR TITLE
feat: user managed identity for gh runners

### DIFF
--- a/app/hack/index.js
+++ b/app/hack/index.js
@@ -1,6 +1,6 @@
 const { getRegistrationToken } = require("../src/github");
 const { v4: uuidv4 } = require("uuid");
-const { createVM, deleteVM, addKeyVaultAccessPolicyForVM, storeKeyVaultSecret } = require("../src/azure");
+const { createVM, deleteVM, storeKeyVaultSecret } = require("../src/azure");
 
 (async () => {
     const now = new Date();
@@ -9,12 +9,8 @@ const { createVM, deleteVM, addKeyVaultAccessPolicyForVM, storeKeyVaultSecret } 
 
     const name = "gh-runner-" + uuidv4();
 
-    const [vmResponse, keyvaultSecretResponse] = await Promise.all([
-        createVM(name),
-        storeKeyVaultSecret(name,token)
-    ]);
-
-    const keyvaultPolicyResponse = await addKeyVaultAccessPolicyForVM(vmResponse.identity);
+    await storeKeyVaultSecret(name,token);
+    await createVM(name);
 
     // const deleteResponse = await deleteVM(name);
 

--- a/modules/app-config/main.tf
+++ b/modules/app-config/main.tf
@@ -10,6 +10,7 @@ locals {
     "github-client-id"                  = var.github_client_id
     "github-organization"               = var.github_organization
     "github-installation-id"            = var.github_installation_id
+    "github-runner-identity"            = var.github_runner_identity
   }
   app_config_secrets = {
     "azure-runner-default-password" = var.azure_runner_default_password_key_vault_id

--- a/modules/app-config/variables.tf
+++ b/modules/app-config/variables.tf
@@ -58,6 +58,10 @@ variable "github_runner_labels" {
   type = list(string)
 }
 
+variable "github_runner_identity" {
+  type = string
+}
+
 variable "azure_runner_default_password_key_vault_id" {
   type = string
 }

--- a/modules/custom-data/custom-data.sh.tpl
+++ b/modules/custom-data/custom-data.sh.tpl
@@ -31,7 +31,6 @@ echo DOCKER_HOST=unix:///run/user/$${USER_ID}/docker.sock >>.env
 echo PATH=/home/$${USER_NAME}/bin:$${PATH} >>.env
 
 # retrieve gh registration token from azure key vault
-sleep 60
 az login --identity --allow-no-subscription
 export REGISTRATION_TOKEN=$(az keyvault secret show -n $(hostname) --vault-name ${registration_key_vault_name} | jq -r '.value')
 


### PR DESCRIPTION
adds user assigned managed identity resource for gh runners
assigns a key vault access policy to that MSI via terraform so runners can read reg tokens
removes key vault access policy from javascript app code as no longer necessary
passes identity to app config so runners can be assigned the correct msi upon create