### PR TITLE
fix: upgrade cosign and cosign installer action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,9 +34,9 @@ jobs:
 
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b #v2.8.1
+        uses: sigstore/cosign-installer@d9374b96fed791ab117111a9a307a92b68bf3145 #v3.9.1
         with:
-          cosign-release: 'v1.13.1'
+          cosign-release: 'v2.5.2'
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf


### PR DESCRIPTION
#117 
This pull request updates the `.github/workflows/docker-publish.yml` file to use newer versions of the `cosign-installer` action and the `cosign` tool.

Version updates:

* Updated `sigstore/cosign-installer` action from version `9becc617647dfa20ae7b1151972e9b3a2c338a2b` (v2.8.1) to `d9374b96fed791ab117111a9a307a92b68bf3145` (v3.9.1).
* Updated the `cosign-release` version from `v1.13.1` to `v2.5.2`.