### PR TITLE
chore: archive repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # Terraform Azure GitHub Runners (self-hosted)
+
+> **⚠️ ARCHIVED REPOSITORY**
+> 
+> This repository is archived and no longer actively maintained. While the code remains available for reference, we recommend considering **GitHub Action runners with Azure Private VNET** as an excellent alternative for connecting runners to your private infrastructure. This approach provides secure connectivity between GitHub-hosted runners and your private Azure resources without the overhead of managing self-hosted runner infrastructure.
+> 
+> For more information, see the [GitHub documentation on using GitHub-hosted runners in Azure private networks](https://docs.github.com/en/actions/using-github-hosted-runners/connecting-to-a-private-network).
+
 This project includes all necessary components to spin up the infrastructure for VM based GitHub self-hosted runners in Azure.  This project was created with some inspiration from the [Philips Lab AWS Solution](https://github.com/philips-labs/terraform-aws-github-runner) with some opinionated changes on what our team at [Liatrio](https://www.liatrio.com/) has seen work well across different enterprises.
 
 #### **These patterns include:**


### PR DESCRIPTION
This pull request updates the `README.md` file to indicate that the repository has been archived and is no longer actively maintained. It provides alternative recommendations for using GitHub Action runners with Azure Private VNET for secure connectivity.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2-R8): Added a notice at the top of the file stating that the repository is archived and recommending GitHub-hosted runners with Azure Private VNET as an alternative. Included a link to relevant GitHub documentation for further details.